### PR TITLE
Cross-platform formula to set a computer name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2016 Maintainers of plus3it/name-computer-formula
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # name-computer-formula
-Salt formula to set the computer name of a system
+Cross-platform salt formula to set the computer name of a system.
+
+## Available States
+
+### name-computer
+
+Set the computer name on Windows, or the hostname on Linux.
+
+## Configuration
+
+The only configuration option is a salt grain, `name-computer:computername`.
+The formula will read the grain, and will set the computer name to the value
+of the grain. If the grain is unset or set to a value that evaluates as
+`False`, then the formula will do nothing.

--- a/name-computer/init.sls
+++ b/name-computer/init.sls
@@ -1,0 +1,7 @@
+{%- from tpldir + "/map.jinja" import name_computer with context %}
+
+{%- if name_computer %}
+Set Computer Name:
+  {{ name_computer.state_name }}:
+    {{ name_computer.state_opts }}
+{%- endif %}

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -1,0 +1,19 @@
+{%- set name = salt['grains.get']('name-computer:computername', '') %}
+
+{%- load_yaml as salt_states %}
+RedHat:
+  state_name: 'network.system'
+  state_opts:
+      - hostname: {{ name }}
+      - apply_hostname: True
+      - retain_settings: True
+Windows:
+  state_name: 'system.computer_name'
+  state_opts:
+      - name: {{ name }}
+{%- endload %}
+
+{%- set name_computer = salt['grains.filter_by'](
+    salt_states,
+    grain='os_family'
+) if name else {} %}


### PR DESCRIPTION
Set the computer name on Windows, or the hostname on Linux. The only configuration option is a salt grain, `name-computer:computername`. The formula will read the grain, and will set the computer name to the value of the grain. If the grain is unset or set to a value that evaluates as `False`, then the formula will do nothing.
