### PR TITLE
Ensure /etc/hosts gets updated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - |
     sudo docker exec centos-${OS_VERSION} yum -y install \
       https://repo.saltstack.com/yum/redhat/salt-repo-latest-2.el${OS_VERSION}.noarch.rpm
-  - sudo docker exec centos-${OS_VERSION} yum -y install salt-minion util-linux-ng
+  - sudo docker exec centos-${OS_VERSION} yum -y install salt-minion util-linux-ng iproute
   - sudo docker exec centos-${OS_VERSION} salt-call --versions-report
   - |
     sudo docker exec centos-${OS_VERSION} salt-call --local \

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   global:
     SALT_FILEROOT: '%APPVEYOR_BUILD_FOLDER%'
     SALT_STATE: name-computer
-    SALT_URL: 'https://repo.saltstack.com/windows/Salt-Minion-2016.11.8-AMD64-Setup.exe'
+    SALT_URL: 'https://repo.saltstack.com/windows/Salt-Minion-2018.3.4-Py2-AMD64-Setup.exe'
     SALT_GRAIN_KEY: 'name-computer:computername'
   matrix:
     - SALT_GRAIN_VALUE: False

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -12,6 +12,11 @@
     salt.pillar.get('name-computer:lookup:computername') | default('', true)
 ) %}
 
+{%- set dns_domain = salt.pillar.get('join-domain:lookup:dns_name') | default('', true) %}
+{%- set base_if = salt['network.default_route']('inet')[0]['interface'] %}
+{%- set base_ip = salt['network.interface'](base_if)[0]['address'] %}
+
+
 {%- load_yaml as salt_states %}
 RedHat:
   Set Computer Name:
@@ -23,6 +28,13 @@ RedHat:
       - hostname: {{ name }}
       - apply_hostname: True
       - retain_settings: True
+
+  Update /etc/hosts:
+    host.present:
+      - ip: {{ base_ip }}
+      - names:
+        - {{ name }}.{{ dns_domain }}
+        - {{ name }}
 Windows:
   Set Computer Name:
     system.computer_name:

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -33,8 +33,8 @@ RedHat:
     host.present:
       - ip: {{ base_ip }}
       - names:
-        - {{ name }}.{{ dns_domain }}
-        - {{ name }}
+        - {{ name|lower }}.{{ dns_domain|lower }}
+        - {{ name|lower }}
 Windows:
   Set Computer Name:
     system.computer_name:

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -29,7 +29,7 @@ RedHat:
 
   Update /etc/hosts:
     host.present:
-      - ip: {{ salt['network.interface'](salt['network.default_route']('inet')[0]['interface'])[0]['address'] }}
+      - ip: {{ salt.network.interface(salt.network.default_route('inet')[0]['interface'])[0]['address'] }}
       - names:
       {%- if dns_domain %}
         - {{ name|lower }}.{{ dns_domain|lower }}

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -12,7 +12,7 @@
     salt.pillar.get('name-computer:lookup:computername') | default('', true)
 ) %}
 
-{%- set dns_domain = salt.pillar.get('join-domain:lookup:dns_name') | default('', true) %}
+{%- set dns_domain = salt.pillar.get('name-computer:lookup:dns_domain') | default('', true) %}
 
 
 {%- load_yaml as salt_states %}
@@ -31,7 +31,9 @@ RedHat:
     host.present:
       - ip: {{ salt['network.interface'](salt['network.default_route']('inet')[0]['interface'])[0]['address'] }}
       - names:
+      {%- if dns_domain %}
         - {{ name|lower }}.{{ dns_domain|lower }}
+      {%- endif %}
         - {{ name|lower }}
 Windows:
   Set Computer Name:

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -29,7 +29,7 @@ RedHat:
 
   Update /etc/hosts:
     host.present:
-      - ip: {{ salt.network.interface(salt.network.default_route('inet')[0]['interface'])[0]['address'] }}
+      - ip: {{ salt.network.get_route('192.0.0.8')['source'] }}
       - names:
       {%- if dns_domain %}
         - {{ name|lower }}.{{ dns_domain|lower }}

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -13,7 +13,6 @@
 ) %}
 
 {%- set dns_domain = salt.pillar.get('join-domain:lookup:dns_name') | default('', true) %}
-{%- set base_ip = salt['network.interface'](salt['network.default_route']('inet')[0]['interface'])[0]['address'] %}
 
 
 {%- load_yaml as salt_states %}
@@ -30,7 +29,7 @@ RedHat:
 
   Update /etc/hosts:
     host.present:
-      - ip: {{ base_ip }}
+      - ip: {{ salt['network.interface'](salt['network.default_route']('inet')[0]['interface'])[0]['address'] }}
       - names:
         - {{ name|lower }}.{{ dns_domain|lower }}
         - {{ name|lower }}

--- a/name-computer/map.jinja
+++ b/name-computer/map.jinja
@@ -13,8 +13,7 @@
 ) %}
 
 {%- set dns_domain = salt.pillar.get('join-domain:lookup:dns_name') | default('', true) %}
-{%- set base_if = salt['network.default_route']('inet')[0]['interface'] %}
-{%- set base_ip = salt['network.interface'](base_if)[0]['address'] %}
+{%- set base_ip = salt['network.interface'](salt['network.default_route']('inet')[0]['interface'])[0]['address'] %}
 
 
 {%- load_yaml as salt_states %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,0 +1,10 @@
+join-domain:
+
+  lookup:
+    ##################################
+    # Linux-specific pillar settings
+    ##################################
+
+    # Required Settings
+    dns_domain: <DNS Domain of Named-Instance>
+

--- a/pillar.example
+++ b/pillar.example
@@ -1,10 +1,10 @@
-join-domain:
+name-computer:
 
   lookup:
     ##################################
     # Linux-specific pillar settings
     ##################################
 
-    # Required Settings
+    # Value used for locally-mapping FQDN to IP
     dns_domain: <DNS Domain of Named-Instance>
 


### PR DESCRIPTION
Adds logic to ensure that the `/etc/hosts` file gets properly updated when the formula is run (closes #11)

Really not sure why Travis is complaining. Have tested the formula to run successfully on both CentOS 6 and CentOS 7 EC2s.